### PR TITLE
Upgrade to tempfile 2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ glob = "0.2"
 regex = "0.1"
 regex-syntax = "0.2"
 log = "0.3"
-tempfile = "1.1"
+tempfile = "2.1"
 walkdir = "0.1"
 
 consts = { path = "src/consts" }

--- a/src/libcindex/Cargo.toml
+++ b/src/libcindex/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Vernon Jones <vernonrjones@gmail.com>"]
 byteorder = "0.5"
 log = "0.3"
 memmap = "0.2"
-tempfile = "1.1"
+tempfile = "2.1"
 
 consts = { path = "../consts" }
 libcsearch = { path = "../libcsearch" }

--- a/src/libcindex/src/merge/merge.rs
+++ b/src/libcindex/src/merge/merge.rs
@@ -35,7 +35,7 @@ use libcsearch::reader::IndexReader;
 use writer::{get_offset, copy_file};
 use libprofiling;
 
-use tempfile::TempFile;
+use tempfile::tempfile;
 use byteorder::{BigEndian, WriteBytesExt};
 use consts;
 
@@ -156,7 +156,7 @@ pub fn merge<P1, P2, P3>(dest: P1, src1: P2, src2: P3) -> io::Result<()>
 
     // Merged list of names
     let name_data = try!(get_offset(&mut ix3));
-    let mut name_index_file = BufWriter::new(try!(TempFile::new()));
+    let mut name_index_file = BufWriter::new(try!(tempfile()));
 
     new = 0;
     mi1 = 0;
@@ -229,7 +229,7 @@ pub fn merge<P1, P2, P3>(dest: P1, src1: P2, src2: P3) -> io::Result<()>
 fn merge_list_of_posting_lists(mut r1: PostMapReader,
                                mut r2: PostMapReader,
                                ix3: &mut BufWriter<File>)
-                               -> io::Result<BufWriter<TempFile>> {
+                               -> io::Result<BufWriter<File>> {
     // Merged list of posting lists.
     let mut w = try!(PostDataWriter::new(ix3));
 

--- a/src/libcindex/src/writer/write.rs
+++ b/src/libcindex/src/writer/write.rs
@@ -14,7 +14,7 @@ use std::ffi::OsString;
 use std::mem;
 
 use libvarint;
-use tempfile::TempFile;
+use tempfile::tempfile;
 use byteorder::{BigEndian, WriteBytesExt};
 use libprofiling;
 
@@ -64,8 +64,8 @@ pub struct IndexWriter {
 
     paths: Vec<OsString>,
 
-    name_data: BufWriter<TempFile>,
-    name_index: BufWriter<TempFile>,
+    name_data: BufWriter<File>,
+    name_index: BufWriter<File>,
 
     trigram: SparseSet,
 
@@ -76,7 +76,7 @@ pub struct IndexWriter {
 
     post: Vec<PostEntry>,
     post_files: Vec<Vec<PostEntry>>,
-    post_index: BufWriter<TempFile>,
+    post_index: BufWriter<File>,
 
     index: BufWriter<File>,
 }
@@ -310,7 +310,7 @@ impl IndexWriter {
     }
 }
 
-fn make_temp_buf() -> io::Result<BufWriter<TempFile>> {
-    let w = try!(TempFile::new());
+fn make_temp_buf() -> io::Result<BufWriter<File>> {
+    let w = try!(tempfile());
     Ok(BufWriter::with_capacity(256 << 10, w))
 }


### PR DESCRIPTION
Now, you can just call `tempfile()` to return a normal `File` object. We no
longer need a special wrapper type because the OS will cleanup the file for us.
